### PR TITLE
fix BuildingSync links

### DIFF
--- a/src/app/tool/building-sync/resources/resources.component.html
+++ b/src/app/tool/building-sync/resources/resources.component.html
@@ -15,14 +15,17 @@
 <h3 class="mat-h3">Other Supporting Documents</h3>
 <p>There are several supporting documents that are independent of the version of the schema. The supporting documents include Example Files, a Geometry Reference Sheet, and an Implementation Guide. More information can be found below.</p>
 
+<h4 class="mat-h4">Building Procurement</h4>
+<p>The <a class="color-2 bold-link" href="https://buildingsync.net/static/documents/BuildingSync-RFP-RFQ-language.pdf" target="_blank">Specifying BuildingSync Templates for RFPs and RFQs <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a> document aids in standardizing the Request for Proposal (RFP) and Request for Qualifications (RFQ) language for BuildingSync and BuildingSync-adjacent projects. The document provides templates that can copied into an RFP or RFQ.</p>
+
 <h4 class="mat-h4">Example Files</h4>
-<p>These <a class="color-2 bold-link" href="https://github.com/BuildingSync/schema/tree/develop/examples" target="_blank">example files <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a> aid in applying the schema to a particular energy auditing software. This collection is not exhaustive, but should still be helpful.</p>
+<p>These <a class="color-2 bold-link" href="https://github.com/BuildingSync/schema/tree/develop-v2/examples" target="_blank">example files <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a> aid in applying the schema to a particular energy auditing software. This collection is not exhaustive, but should still be helpful.</p>
+
+<h4 class="mat-h4">Onboarding Guide</h4>
+<p>The <a class="color-2 bold-link" href="https://buildingsync.net/static/documents/BuildingSync-on-boarding.pdf" target="_blank">Onboarding Guide <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a> is a document illustrating the process to adopt an instance of the BuildingSync schema. The Guide provides context for BuildingSync use cases and how they are used to downselect the important fields in BuildingSync for a specific use case.</p>
 
 <h4 class="mat-h4">Geometry Reference Sheet</h4>
-<p>The BuildingSync <a class="color-2 bold-link" href="https://github.com/BuildingSync/schema/blob/develop/docs/Geometry%20Reference.pdf" target="_blank">Geometry Reference Sheet <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a> illustrates how most of the simplified geometric terms (shapes, side names, vertices, orientations) are defined in the context of BuildingSync.</p>
-
-<h4 class="mat-h4">Implementation Guide</h4>
-<p>The <a class="color-2 bold-link" href="https://buildingsync.net/documents/BuildingSync%20v1.0-legacy%20Implementation%20Guide.pdf" target="_blank">Implementation Guide <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a> is a comprehensive guide illustrating the process needed to adopt the BuildingSync schema. The Guide also provides context for BuildingSync and discusses how it has been developed in close coordination with the energy auditing industry.</p>
+<p>The BuildingSync <a class="color-2 bold-link" href="https://github.com/BuildingSync/schema/releases/download/v2.4.0/geometry_reference.pdf" target="_blank">Geometry Reference Sheet <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a> illustrates how most of the simplified geometric terms (shapes, side names, vertices, orientations) are defined in the context of BuildingSync.</p>
 
 <h3 class="mat-h3">Publications and Presentations</h3>
 
@@ -32,21 +35,21 @@
 
 <h4 class="mat-h4">2020</h4>
 
-<p><a class="color-2 bold-link" href="https://buildingsync.net/documents/Mosiman-BPAC-2020.pdf" target="_blank">Mosiman, Cory, Nicholas Lee Long, Tobias Maile, Katherine Fleming and Christopher CaraDonna. 2020. “High-Level Model Articulation with BuildingSync and OpenStudio.” In ASHRAE and IBPSA-USA SimBuild 2020 Building Performance Analysis Conference, Virtual Conference. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
+<p><a class="color-2 bold-link" href="https://buildingsync.net/static/documents/Mosiman-BPAC-2020.pdf" target="_blank">Mosiman, Cory, Nicholas Lee Long, Tobias Maile, Katherine Fleming and Christopher CaraDonna. 2020. “High-Level Model Articulation with BuildingSync and OpenStudio.” In ASHRAE and IBPSA-USA SimBuild 2020 Building Performance Analysis Conference, Virtual Conference. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
 <p>Long, Nicholas, Katherine Fleming, Cory Mosiman, Harry Bergmann, Mark Borkum, Ted Summer, Christopher Naismith. “BuildingSync Webinar.” September 11, 2020. <a class="color-2 bold-link" href="https://nrel-seed.s3.us-east-1.amazonaws.com/resources/2020-09-11%20-%20BuildingSync%20Update%20Presentation.pdf">Webinar Presentation. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a>&nbsp;&nbsp;<a class="color-2 bold-link" href="https://nrel-seed.s3.us-east-1.amazonaws.com/resources/2020-09-11%20-%20BuildingSync%20Update%20Webinar.mp4" target="_blank">Webinar Recording <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
 <h4 class="mat-h4">2018</h4>
 
-<p><a class="color-2 bold-link" href="https://buildingsync.net/documents/Hooper-ACEEE-BRICR.pdf" target="_blank">Hooper, Barry, Tianzhen Hong, Daniel Macumber, Sang Hoon Lee, Yixing Chen, Nicholas Long, Edwin Lee, et al. 2018. “The BayREN Integrated Commercial Retrofits (BRICR) Project : An Introduction and Preliminary Results Overview of BRICR Software Tools and Workflow.” In 2018 ACEEE Summer Study on Energy Efficiency in Buildings, 1–12. Pacific Grove, CA. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
+<p><a class="color-2 bold-link" href="https://buildingsync.net/static/documents/Hooper-ACEEE-BRICR.pdf" target="_blank">Hooper, Barry, Tianzhen Hong, Daniel Macumber, Sang Hoon Lee, Yixing Chen, Nicholas Long, Edwin Lee, et al. 2018. “The BayREN Integrated Commercial Retrofits (BRICR) Project : An Introduction and Preliminary Results Overview of BRICR Software Tools and Workflow.” In 2018 ACEEE Summer Study on Energy Efficiency in Buildings, 1–12. Pacific Grove, CA. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
-<p><a class="color-2 bold-link" href="https://buildingsync.net/documents/DeGraw-ACEEE-BuildingSync-in-Action.pdf" target="_blank">DeGraw, Jason, Kristin Field-Macumber, Nicholas Long, and Supriya Goel. 2018. “BuildingSync&reg; in Action : Example Implementations.” In 2018 ACEEE Summer Study on Energy Efficiency in Buildings, 1–12. Pacific Grove, CA. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
+<p><a class="color-2 bold-link" href="https://buildingsync.net/static/documents/DeGraw-ACEEE-BuildingSync-in-Action.pdf" target="_blank">DeGraw, Jason, Kristin Field-Macumber, Nicholas Long, and Supriya Goel. 2018. “BuildingSync&reg; in Action : Example Implementations.” In 2018 ACEEE Summer Study on Energy Efficiency in Buildings, 1–12. Pacific Grove, CA. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
-<p><a class="color-2 bold-link" href="https://buildingsync.net/documents/Kelsey-ACEEE-Std211.pdf" target="_blank">Kelsey, Jim. 2018. “Developing ASHRAE’s First Standard for Commercial Energy Audits (Or; How I Spent My Summer Vacations).” In 2018 ACEEE Summer Study on Energy Efficiency in Buildings, 1–14. Pacific Grove, CA. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
+<p><a class="color-2 bold-link" href="https://buildingsync.net/static/documents/Kelsey-ACEEE-Std211.pdf" target="_blank">Kelsey, Jim. 2018. “Developing ASHRAE’s First Standard for Commercial Energy Audits (Or; How I Spent My Summer Vacations).” In 2018 ACEEE Summer Study on Energy Efficiency in Buildings, 1–14. Pacific Grove, CA. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
 <p><a class="color-2 bold-link" href="http://www.kw-engineering.com/buildingsync-energy-audits-benefits/" target="_blank">Kelsey, Jim. 2018. “An XML-Ent Match Made in Energy Efficiency: BuildingSync and Energy Audits - KW Engineering.” <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
-<p><a class="color-2 bold-link" href="https://buildingsync.net/documents/Taylor-ACEEE-Ordinances.pdf" target="_blank">Taylor, Cody, Marc Costa, Nicholas Long, and Jayson Antonoff. 2016. “A National Framework for Energy Audit Ordinances.” In 2016 ACEEE Summer Study on Energy Efficiency in Buildings, 1–12. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
+<p><a class="color-2 bold-link" href="https://buildingsync.net/static/documents/Taylor-ACEEE-Ordinances.pdf" target="_blank">Taylor, Cody, Marc Costa, Nicholas Long, and Jayson Antonoff. 2016. “A National Framework for Energy Audit Ordinances.” In 2016 ACEEE Summer Study on Energy Efficiency in Buildings, 1–12. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
 <p><a class="color-2 bold-link" href="https://www.ashrae.org/technical-resources/bookstore/standards-180-and-211" target="_blank">ASHRAE. 2018. “BSR/ASHRAE/ACCA Standard Standard 211-2018.” Atlanta, GA. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
@@ -56,8 +59,8 @@
 
 <h4 class="mat-h4">2016</h4>
 
-<p><a class="color-2 bold-link" href="https://buildingsync.net/documents/Balbach-IBPSA-QAQC.pdf" target="_blank">Balbach, Chris, and David Bosworth. 2016. “Automated Methods for Improving Energy Model Quality Assurance and Quality Control.” In ASHRAE and IBPSA-USA SimBuild 2016 Building Performance Modeling Conference, 385–92. Salt Lake City, UT. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
+<p><a class="color-2 bold-link" href="https://buildingsync.net/static/documents/Balbach-IBPSA-QAQC.pdf" target="_blank">Balbach, Chris, and David Bosworth. 2016. “Automated Methods for Improving Energy Model Quality Assurance and Quality Control.” In ASHRAE and IBPSA-USA SimBuild 2016 Building Performance Modeling Conference, 385–92. Salt Lake City, UT. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
 <p><a class="color-2 bold-link" href="http://cbei.psu.edu/wp-content/uploads/2016/07/Broadening-Use-of-DOE-BTO-Tools-in-the-SMSCB-Market.pdf" target="_blank">Cochran, Erica, and Alon Abramson. 2016. “Broadening Use of DOE BTO Tools in the SMSCB Market Report.” <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
 
-<p><a class="color-2 bold-link" href="https://buildingsync.net/documents/Eley-IPBSA-StandardizeOutputs.pdf" target="_blank">Eley, Charles. 2016. “Standardizing Energy Modeling Output.” In ASHRAE and IBPSA-USA SimBuild 2016, 365–71. Salt Lake City, UT. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>
+<p><a class="color-2 bold-link" href="https://buildingsync.net/static/documents/Eley-IPBSA-StandardizeOutputs.pdf" target="_blank">Eley, Charles. 2016. “Standardizing Energy Modeling Output.” In ASHRAE and IBPSA-USA SimBuild 2016, 365–71. Salt Lake City, UT. <span class="ml-1 align-center"><i class="fas fa-external-link-alt"></i></span></a></p>


### PR DESCRIPTION
* fix links to github references
* static documents on buildingsync.net are now at `static/documents`
* add in Building Procurement section with the RFP/RFQ document